### PR TITLE
feat: Move userAgent at the beginning of the execution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,15 @@ class AmazonContentScript extends ContentScript {
   // P
   async ensureAuthenticated() {
     this.log('info', 'Starting ensureAuth')
+    await this.bridge.call(
+      'setUserAgent',
+      'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0'
+    )
     await this.bridge.call('setWorkerState', {
       url: baseUrl,
       visible: false
     })
-    await this.waitForElementInWorker('#nav-progressive-greeting')
+    await this.waitForElementInWorker('#nav-link-accountList')
     const authenticated = await this.runInWorker('checkAuthenticated')
     this.log('debug', 'Authenticated : ' + authenticated)
     if (authenticated) {
@@ -57,21 +61,15 @@ class AmazonContentScript extends ContentScript {
     )
     if (isConnected) {
       await this.runInWorker('click', 'a[href*="/gp/flex/sign-out.html?"]')
-      await Promise.race([
-        this.waitForElementInWorker('#ap_email_login'),
-        this.waitForElementInWorker('#ap_password')
-      ])
-      if (await this.isElementInWorker('#ap_password')) {
-        throw new Error(
-          'The logout leads to the password page, cannot save a login value for sourceAccountIdentifier'
-        )
-      }
+      await this.waitForElementInWorker('#ap_email_login')
     }
   }
 
   // W
   async checkAuthenticated() {
-    const result = Boolean(document.querySelector('#nav-greeting-name'))
+    const result = Boolean(
+      document.querySelector('a[href*="/gp/flex/sign-out.html?"]')
+    )
     this.log('debug', 'Authentification detection : ' + result)
     return result
   }
@@ -83,18 +81,19 @@ class AmazonContentScript extends ContentScript {
       url: baseUrl,
       visible: false
     })
-    await this.waitForElementInWorker('a[id="nav-logobar-greeting"]')
-    await this.clickAndWait('a[id="nav-logobar-greeting"]', '#ap_email_login')
-    // Enter login
-    const emailFieldSelector = '#ap_email_login'
-    await this.runInWorker('fillText', emailFieldSelector, credentials.email)
+    await this.waitForElementInWorker('#nav-link-accountList')
+    await this.runInWorker('click', '#nav-link-accountList')
+    await Promise.all([
+      this.waitForElementInWorker('#ap_email'),
+      this.waitForElementInWorker('#continue')
+    ])
 
+    // Enter login
+    const emailFieldSelector = '#ap_email'
+    await this.runInWorker('fillText', emailFieldSelector, credentials.email)
     // Click continue
     // Watch out: multiples input#continue buttons
-    await this.clickAndWait(
-      'input#continue[aria-labelledby="continue-announce"]',
-      '[name="rememberMe"]'
-    )
+    await this.clickAndWait('input[id="continue"]', '[name="rememberMe"]')
 
     // Enter password
     const passFieldSelector = '#ap_password'
@@ -110,7 +109,7 @@ class AmazonContentScript extends ContentScript {
 
   // W
   findAndSendCredentials() {
-    const emailField = document.querySelector('#ap_email_login')
+    const emailField = document.querySelector('#ap_email')
     const passwordField = document.querySelector('#ap_password')
     this.log('debug', 'Executing findAndSendCredentials')
     if (emailField) {
@@ -133,8 +132,8 @@ class AmazonContentScript extends ContentScript {
       url: baseUrl,
       visible: false
     })
-    await this.waitForElementInWorker('a[id="nav-logobar-greeting"]')
-    await this.clickAndWait('a[id="nav-logobar-greeting"]', '#ap_email_login')
+    await this.waitForElementInWorker('#nav-link-accountList')
+    await this.clickAndWait('#nav-link-accountList', '#ap_email')
 
     await this.bridge.call('setWorkerState', {
       visible: true
@@ -154,7 +153,7 @@ class AmazonContentScript extends ContentScript {
 
   // W
   async setListenerLogin() {
-    const loginField = document.querySelector('#ap_email_login')
+    const loginField = document.querySelector('#ap_email')
     if (loginField) {
       loginField.addEventListener(
         'change',
@@ -186,13 +185,10 @@ class AmazonContentScript extends ContentScript {
 
   // P
   async fetch(context) {
+    this.log('info', 'Starting fetch')
     if (this.store && (this.store.email || this.store.password)) {
       await this.saveCredentials(this.store)
     }
-    await this.bridge.call(
-      'setUserAgent',
-      'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0'
-    )
     await this.waitForElementInWorker('#nav_prefetch_yourorders')
     await this.clickAndWait('#nav_prefetch_yourorders', "[name='orderFilter']")
     const years = await this.runInWorker('getYears')
@@ -323,6 +319,7 @@ class AmazonContentScript extends ContentScript {
 
   // P
   async getUserDataFromWebsite() {
+    this.log('info', 'Starting getUserDataFromWebsite')
     if (this.store && this.store.email) {
       return {
         sourceAccountIdentifier: this.store.email


### PR DESCRIPTION
This PR moves the setting of the userAgent at the beggining of the execution of the konnector for stability purpose.

Changing the user agent like this makes the website switches to the desktop version of the website, it was easier for the scraping, but bring it all up like this leads to some changes in the used selectors to navigate, click, or scrap the credentials for example, so this PR change the required selectors too

We also removed the 'month-3' period form fetched years because the presented page is completly different from the others page, leading the bills fetching to fail. No worries tho, every order present in this page are also present in the current year page (for example for 2023, all the orders from "the last 3 months" are there too, or at least in the previous year for orders from the 2 first month of the year)