### PR TITLE
[SCR-557 SCR-558] Fix/link but no download

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -473,6 +473,21 @@ class AmazonContentScript extends ContentScript {
               wantedId++
             } else {
               message = `🏮️ Link ${wantedId} not visible, retrying`
+              await this.evaluateInWorker(() => {
+                const popoverDisplaysAlert = document
+                  .querySelector(`#a-popover-${wantedId}`)
+                  .querySelector('.a-icon-alert')
+                // If website did not manage to load the downloadLinks it shows an error in the popover
+                // If it happens, close and click again on the link usually resolve the issue.
+                // To do so, just click outside the popover on any element (here I choose the white background), this will close the popover
+                if (popoverDisplaysAlert) {
+                  this.log(
+                    'info',
+                    'Website generate an error when trying to show downloadLinks, retrying ...'
+                  )
+                  document.querySelector('#a-page').click()
+                }
+              })
             }
             this.log('info', message)
             return isOk

--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,7 @@ class AmazonContentScript extends ContentScript {
     if (years[0] !== 'months-3') {
       await this.runInWorker('deleteElement', '.num-orders')
       // ///////////// USED TO DEBUG A SPECIFIC YEAR /////
-      // years = ['year-2022']
+      // years = ['year-2020']
       // /////////////////////////////////////////////////
       await this.navigateToNextPeriod(years[0])
     }
@@ -549,7 +549,7 @@ class AmazonContentScript extends ContentScript {
       if (commands === null) {
         continue
       }
-      if (commands === 'audiobook') {
+      if (commands === 'audiobook' || commands === 'noBill') {
         wantedId++
         continue
       }
@@ -650,7 +650,7 @@ class AmazonContentScript extends ContentScript {
         'info',
         'Found an article with no bill attached to it, jumping this bill'
       )
-      return null
+      return 'noBill'
     }
     const fileurl = urlsArray.length > 1 ? urlsArray : urlsArray[0]
     let command = {


### PR DESCRIPTION
This PR fixes some missed bills when order shows the showBillsButton but had no bill to download by incrementing the wantedId when this happens, ensuring we try current id and despite being present, still have no bills to download.

It also avoid infinite loop when website did not load the downloadLink. If so an error will show in the just-opened popover. If this happen, a simple click anywhere closes the popover and let the "makeBillDownloadLinkVisible" click on it again. Fixes the loading issues 100% of the time when developing 